### PR TITLE
feat: `@prisma/adapter-pg` 기반 Read Replication 구현

### DIFF
--- a/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceFile.ts
@@ -238,12 +238,31 @@ function buildClientOptions(context: GenerateContext, options: TSClientOptions) 
     ['library', 'client', 'wasm-compiler-edge', 'wasm-engine-edge'].includes(options.runtimeName) &&
     context.isPreviewFeatureOn('driverAdapters')
   ) {
+    const adapterOptions = ts
+      .objectType()
+      .add(ts.property('primary', ts.namedType('runtime.SqlDriverAdapterFactory')))
+      .add(
+        ts
+          .property('replica', ts.unionType([ts.namedType('runtime.SqlDriverAdapterFactory'), ts.namedType('null')]))
+          .optional(),
+      )
+
     clientOptions.add(
       ts
-        .property('adapter', ts.unionType([ts.namedType('runtime.SqlDriverAdapterFactory'), ts.namedType('null')]))
+        .property('adapter', adapterOptions)
         .optional()
         .setDocComment(
-          ts.docComment('Instance of a Driver Adapter, e.g., like one provided by `@prisma/adapter-planetscale`'),
+          ts.docComment(`Instance of a Driver Adapter, e.g., like one provided by \`@prisma/adapter-pg\`
+
+@example
+\`\`\`
+const prisma = new PrismaClient({
+  adapter: {
+    primary: new PrismaPg(),
+    replica: new PrismaPg(), // (optional) if not provided, the read operations will only use the primary adapter
+  },
+})
+\`\`\``),
         ),
     )
   }

--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -88,6 +88,7 @@ type ExecutorKind =
   | {
       remote: false
       driverAdapterFactory: SqlDriverAdapterFactory
+      driverAdapterROFactory?: SqlDriverAdapterFactory
     }
   | { remote: true }
 
@@ -121,7 +122,11 @@ export class ClientEngine implements Engine {
     if (remote) {
       this.#executorKind = { remote: true }
     } else if (config.adapter) {
-      this.#executorKind = { remote: false, driverAdapterFactory: config.adapter }
+      this.#executorKind = {
+        remote: false,
+        driverAdapterFactory: config.adapter,
+        driverAdapterROFactory: config.adapterRO,
+      }
       debug('Using driver adapter: %O', config.adapter)
     } else {
       throw new PrismaClientInitializationError(
@@ -233,6 +238,7 @@ export class ClientEngine implements Engine {
     } else {
       return await LocalExecutor.connect({
         driverAdapterFactory: this.#executorKind.driverAdapterFactory,
+        driverAdapterROFactory: this.#executorKind.driverAdapterROFactory,
         tracingHelper: this.tracingHelper,
         transactionOptions: {
           ...this.config.transactionOptions,

--- a/packages/client/src/runtime/core/engines/common/Engine.ts
+++ b/packages/client/src/runtime/core/engines/common/Engine.ts
@@ -157,6 +157,13 @@ export interface EngineConfig {
   adapter?: SqlDriverAdapterFactory
 
   /**
+   * Instance of a Read Only Driver Adapter, e.g., like one provided by `@prisma/adapter-pg`.
+   * If set, this is only used in the LocalExecutor, and all queries would be performed through it,
+   * @remarks only used by LocalExecutor.ts
+   */
+  adapterRO?: SqlDriverAdapterFactory
+
+  /**
    * The contents of the schema encoded into a string
    */
   inlineSchema: string


### PR DESCRIPTION
# Description of this PR

Query Operation을 판단하여 Read/Write 커넥션을 정할 수 있게 설정함

### Reader Instance로 라우팅 되는 경우
1. PrismaClient 초기화 시 Read Replica를 설정했고
   ```ts
   const prisma = new PrismaClient({
     adapter: {
       primary: new PrismaPg(),
       replica: new PrimsaPg(), // 여기에 PrismaPg 어댑터를 초기화 해줘야 함. (null이면 동작 x)
     }
   })
   ```
2. 쿼리가 Prisma 트랜잭션에 포함되어 있지 않으며
3. 아래 Operation을 만족하는 경우 Reader로 라우팅 됨
   - findFirst
   - findFirstOrThrow
   - findMany
   - findUnique
   - findUniqueOrThrow
   - groupBy
   - aggregate
   - count
   - findRaw
   - aggregateRaw

<br/>

> [!NOTE]
> Q) SELECT 절로만 이루어진 `$queryRaw` 또는 `$queryRawUnsafe`도 Read Replica를 사용하는지?
> A) Raw Query는 Writer로만 라우팅됩니다.