### PR TITLE
feat: 동적 Read Replication 지원

### DIFF
--- a/packages/client-generator-ts/src/TSClient/PrismaClient.ts
+++ b/packages/client-generator-ts/src/TSClient/PrismaClient.ts
@@ -323,7 +323,7 @@ export interface PrismaClient<
   $disconnect(): runtime.Types.Utils.JsPromise<void>;
 
   /**
-   * Returns the request context (AsyncLocalStorage)
+   * Returns the request context
    * @returns RequestContext
    */
   $context(): RequestContext;

--- a/packages/client-generator-ts/src/TSClient/RequestContext.ts
+++ b/packages/client-generator-ts/src/TSClient/RequestContext.ts
@@ -2,9 +2,9 @@ export class RequestContext {
   constructor() {}
   public toTS(): string {
     return [
-      'export type DynamicSchema = { from: string; to: string }',
-      'export type RequestContextPayload = { dynamicSchemas?: DynamicSchema[]; usePrimary?: boolean }',
-      'export type RequestContext = AsyncLocalStorage<RequestContextPayload>',
+      'export type RequestContext = {',
+      '  init: <R>(cb: () => R, opts?: { schema?: string; usePrimary?: boolean }) => R',
+      '}',
     ].join('\n')
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -327,5 +327,8 @@
       "optional": true
     }
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "dependencies": {
+    "lru-cache": "11.2.2"
+  }
 }

--- a/packages/client/src/runtime/core/engines/client/LocalExecutor.ts
+++ b/packages/client/src/runtime/core/engines/client/LocalExecutor.ts
@@ -11,19 +11,6 @@ import type { ConnectionInfo, SqlDriverAdapter, SqlDriverAdapterFactory } from '
 import type { InteractiveTransactionInfo } from '../common/types/Transaction'
 import type { ExecutePlanParams, Executor, ProviderAndConnectionInfo } from './Executor'
 
-const readOperations = [
-  'findUnique',
-  'findUniqueOrThrow',
-  'findFirst',
-  'findFirstOrThrow',
-  'findMany',
-  'aggregate',
-  'groupBy',
-  'count',
-  'findRaw',
-  'aggregateRaw',
-]
-
 export interface LocalExecutorOptions {
   driverAdapterFactory: SqlDriverAdapterFactory
   driverAdapterReplicaFactory?: SqlDriverAdapterFactory
@@ -82,17 +69,10 @@ export class LocalExecutor implements Executor {
     return Promise.resolve({ provider: this.#driverAdapter.provider, connectionInfo })
   }
 
-  async execute({
-    plan,
-    placeholderValues,
-    transaction,
-    batchIndex,
-    operation,
-    usePrimary,
-  }: ExecutePlanParams): Promise<unknown> {
+  async execute({ plan, placeholderValues, transaction, batchIndex, usePrimary }: ExecutePlanParams): Promise<unknown> {
     const queryable = transaction
       ? await this.#transactionManager.getTransaction(transaction, batchIndex !== undefined ? 'batch query' : 'query')
-      : usePrimary !== true && this.#driverAdapterReplica !== undefined && readOperations.includes(operation)
+      : this.#driverAdapterReplica !== undefined && usePrimary !== true
         ? this.#driverAdapterReplica
         : this.#driverAdapter
 

--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
@@ -1,12 +1,11 @@
 import { RuntimeDataModel, RuntimeModel, uncapitalize } from '@prisma/client-common'
 import { assertNever } from '@prisma/internals'
 
-import { ErrorFormat } from '../../getPrismaClient'
+import { ErrorFormat, RequestContextPayload } from '../../getPrismaClient'
 import { CallSite } from '../../utils/CallSite'
 import { isDate, isValidDate } from '../../utils/date'
 import { isDecimalJsLike } from '../../utils/decimalJsLike'
 import {
-  DynamicSchema,
   JsonArgumentValue,
   JsonFieldSelection,
   JsonQuery,
@@ -32,6 +31,7 @@ import {
 } from '../types/exported/JsApi'
 import { ObjectEnumValue, objectEnumValues } from '../types/exported/ObjectEnums'
 import { ValidationError } from '../types/ValidationError'
+import { isWrite } from './isWrite'
 
 const jsActionToProtocolAction: Record<Action, JsonQueryAction> = {
   findUnique: 'findUnique',
@@ -76,8 +76,7 @@ export type SerializeParams = {
   errorFormat: ErrorFormat
   previewFeatures: string[]
   globalOmit?: GlobalOmitOptions
-  dynamicSchemas?: DynamicSchema[]
-  usePrimary?: boolean
+  requestCtx?: RequestContextPayload
 }
 
 const STRICT_UNDEFINED_ERROR_MESSAGE = 'explicitly `undefined` values are not allowed'
@@ -94,8 +93,7 @@ export function serializeJsonQuery({
   clientVersion,
   previewFeatures,
   globalOmit,
-  dynamicSchemas,
-  usePrimary,
+  requestCtx,
 }: SerializeParams): JsonQuery {
   const context = new SerializeContext({
     runtimeDataModel,
@@ -113,12 +111,14 @@ export function serializeJsonQuery({
     globalOmit,
   })
   const { schema, ...extractedArgs } = args ?? {}
+  const protocolAction = jsActionToProtocolAction[action]
+
   return {
     modelName,
-    action: jsActionToProtocolAction[action],
+    action: protocolAction,
     query: serializeFieldSelection(extractedArgs, context),
-    schemaRequest: serializeSchemaRequest(dynamicSchemas, schema),
-    usePrimary: usePrimary ?? false,
+    schemaRequest: serializeSchemaRequest(requestCtx, schema),
+    usePrimary: determineUsePrimary(requestCtx, protocolAction),
   }
 }
 
@@ -163,21 +163,33 @@ function serializeSelectionSet(
 }
 
 function serializeSchemaRequest(
-  dynamicSchemas: DynamicSchema[] = [],
-  forceSchema?: string,
+  requestCtx: RequestContextPayload | undefined,
+  forceSchema: string | undefined,
 ): Record<string, string> | undefined {
-  dynamicSchemas = dynamicSchemas?.map((schema) => ({ ...schema })) ?? []
-  const serializedSchemas = Object.fromEntries(dynamicSchemas.map((schema) => [schema.from, schema.to]))
+  const serializedSchema: Record<string, string> = {}
 
-  if (forceSchema && /^hospital([1-9]{1})([0-9]+)?$/.test(forceSchema)) {
-    serializedSchemas['hospital_template'] = forceSchema
-  }
+  if (forceSchema) serializedSchema['hospital_template'] = forceSchema
+  else if (requestCtx?.schema) serializedSchema['hospital_template'] = requestCtx.schema
 
-  if (Object.keys(serializedSchemas).length === 0) {
+  if (Object.keys(serializedSchema).length === 0) {
     return undefined
   }
 
-  return serializedSchemas
+  return serializedSchema
+}
+
+function determineUsePrimary(requestCtx: RequestContextPayload | undefined, action: JsonQueryAction) {
+  if (requestCtx?.usePrimary === true) {
+    return true
+  }
+
+  const usePrimary = requestCtx?.usePrimary ?? isWrite(action)
+
+  if (requestCtx !== undefined && usePrimary === true) {
+    requestCtx.usePrimary = usePrimary
+  }
+
+  return usePrimary
 }
 
 function createImplicitSelection(

--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
@@ -183,7 +183,7 @@ function determineUsePrimary(requestCtx: RequestContextPayload | undefined, acti
     return true
   }
 
-  const usePrimary = requestCtx?.usePrimary ?? isWrite(action)
+  const usePrimary = isWrite(action)
 
   if (requestCtx !== undefined && usePrimary === true) {
     requestCtx.usePrimary = usePrimary

--- a/packages/client/src/runtime/core/model/applyModel.ts
+++ b/packages/client/src/runtime/core/model/applyModel.ts
@@ -100,7 +100,7 @@ function modelActionsLayer(client: Client, dmmfModelName: string): CompositeProx
               callsite: callSite,
 
               // dynamic schemas
-              requestCtx: client.$context().getStore() ?? {},
+              requestCtx: client._requestContext.get(client._alsContext.getStore()?.id ?? ''),
             }
 
             return client._request({ ...params, ...paramOverrides })

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -7,6 +7,7 @@ import { ExtendedSpanOptions, logger, TracingHelper, tryLoadEnvs } from '@prisma
 import { AsyncLocalStorage, AsyncResource } from 'async_hooks'
 import { EventEmitter } from 'events'
 import fs from 'fs'
+import { LRUCache } from 'lru-cache'
 import path from 'path'
 import { RawValue, Sql } from 'sql-template-tag'
 
@@ -17,7 +18,7 @@ import {
   PrismaClientValidationError,
 } from '.'
 import { addProperty, createCompositeProxy, removeProperties } from './core/compositeProxy'
-import { BatchTransactionOptions, DynamicSchema, Engine, EngineConfig, Options } from './core/engines'
+import { BatchTransactionOptions, Engine, EngineConfig, Options } from './core/engines'
 import { AccelerateEngineConfig } from './core/engines/accelerate/AccelerateEngine'
 import { AccelerateExtensionFetchDecorator } from './core/engines/common/Engine'
 import { EngineEvent, LogEmitter } from './core/engines/common/types/Events'
@@ -91,11 +92,14 @@ export type ErrorFormat = 'pretty' | 'colorless' | 'minimal'
 export type Datasource = { url?: string }
 export type Datasources = { [name in string]: Datasource }
 
+export type RequestContext = {
+  init: <R>(cb: () => R, opts?: { schema?: string; usePrimary?: boolean }) => R
+}
 export type RequestContextPayload = {
-  dynamicSchemas?: DynamicSchema[]
+  id: string
+  schema?: string
   usePrimary?: boolean
 }
-export type RequestContext = AsyncLocalStorage<RequestContextPayload>
 
 export type PrismaClientOptions = {
   /**
@@ -191,7 +195,7 @@ export type InternalRequestParams = {
   /** Used for Accelerate client extension via Data Proxy */
   customDataProxyFetch?: AccelerateExtensionFetchDecorator
   /** Used to get the request context */
-  requestCtx: RequestContextPayload
+  requestCtx?: RequestContextPayload
 } & Omit<QueryMiddlewareParams, 'runInTransaction'>
 
 export type MiddlewareArgsMapper<RequestArgs, MiddlewareArgs> = {
@@ -270,7 +274,14 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
      */
     _appliedParent: PrismaClient
     _createPrismaPromise = createPrismaPromiseFactory()
-    _requestContext: RequestContext = new AsyncLocalStorage<RequestContextPayload>()
+    _requestContext = new LRUCache<string, RequestContextPayload>({
+      max: 50_000,
+      ttl: 10_000,
+      ttlResolution: 100,
+      updateAgeOnHas: true,
+      updateAgeOnGet: true,
+    })
+    _alsContext = new AsyncLocalStorage<{ id: string }>()
 
     constructor(optionsArg?: PrismaClientOptions) {
       config = optionsArg?.__internal?.configOverride?.(config) ?? config
@@ -474,7 +485,19 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
      * @returns RequestContext
      */
     $context(): RequestContext {
-      return this._requestContext
+      return {
+        init: (cb, opts) => {
+          const id = crypto.randomUUID()
+
+          this._requestContext.set(id, {
+            id,
+            schema: opts?.schema,
+            usePrimary: opts?.usePrimary,
+          })
+
+          return this._alsContext.run({ id }, cb)
+        },
+      }
     }
 
     $on<E extends ExtendedEventType>(eventType: E, callback: EventCallback<E>): PrismaClient {
@@ -533,7 +556,7 @@ export function getPrismaClient(config: GetPrismaClientConfig) {
         callsite: getCallSite(this._errorFormat),
         dataPath: [],
         middlewareArgsMapper,
-        requestCtx: this._requestContext.getStore() ?? {},
+        requestCtx: this._getContextPayload(),
       })
     }
 
@@ -609,7 +632,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
           argsMapper: rawCommandArgsMapper,
           callsite: getCallSite(this._errorFormat),
           transaction: transaction,
-          requestCtx: this._requestContext.getStore() ?? {},
+          requestCtx: this._getContextPayload(),
         })
       })
     }
@@ -634,7 +657,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
         callsite: getCallSite(this._errorFormat),
         dataPath: [],
         middlewareArgsMapper,
-        requestCtx: this._requestContext.getStore() ?? {},
+        requestCtx: this._getContextPayload(),
       })
     }
 
@@ -788,6 +811,8 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
     $transaction(input: any, options?: any) {
       let callback: () => Promise<any>
 
+      this._setPrimary()
+
       // iTx - Interactive transaction
       if (typeof input === 'function') {
         if (this._engineConfig.adapter?.adapterName === '@prisma/adapter-d1') {
@@ -923,8 +948,7 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
             clientVersion: this._clientVersion,
             previewFeatures: this._previewFeatures,
             globalOmit: this._globalOmit,
-            dynamicSchemas: requestCtx.dynamicSchemas,
-            usePrimary: requestCtx.usePrimary,
+            requestCtx,
           }),
         )
 
@@ -980,6 +1004,24 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
     }
 
     $extends = $extends
+
+    _getContextPayload(): RequestContextPayload | undefined {
+      const store = this._alsContext.getStore()
+      if (!store) {
+        return undefined
+      }
+      return this._requestContext.get(store.id)
+    }
+
+    _setPrimary() {
+      const requestCtx = this._getContextPayload()
+      if (!requestCtx) {
+        return
+      }
+
+      requestCtx.usePrimary = true
+      this._requestContext.set(requestCtx.id, requestCtx)
+    }
   }
 
   return PrismaClient

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,6 +541,10 @@ importers:
         version: 3.24.2
 
   packages/client:
+    dependencies:
+      lru-cache:
+        specifier: 11.2.2
+        version: 11.2.2
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250408.0
@@ -5976,6 +5980,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.2.2:
+    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
+    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -12640,6 +12648,8 @@ snapshots:
   loupe@3.1.4: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.2.2: {}
 
   lru-cache@5.1.1:
     dependencies:


### PR DESCRIPTION
# Description of this PR

- 요청 내 Write Operation 실행된 이후부터, 모든 쿼리는 Writer 인스턴스로 쿼리가 전달되도록 변경

<br/>

### 예시
- 한 요청 내에서 `SELECT`, `SELECT`, `UPDATE`, `SELECT` 쿼리가 실행되어야 할 때,
- 기존에는 `read`, `read`, `write`, `read`로 쿼리가 전달되었지만
- 현 PR에서는 `read`, `read`, `write`, `write`로 쿼리가 전달됨

<br/>

### 동작 설명
1. AsyncLocalStorage로 요청 컨텍스트를 생성함 (랜덤 UUID 부여)
   - LRUCache를 이용해 요청 컨텍스트 ttl 관리
2. [isWrite()](https://github.com/vetching-corporation/prisma/blob/typescript-engine/6.18.0/base/packages/client/src/runtime/core/jsonProtocol/isWrite.ts) 함수로 호출된 쿼리의 Operation을 판단 (원래 있던 함수)
   - Write Operation이면 요청 컨텍스트의 `usePrimary` 필드를 `true`로 변경
3. `usePrimary` 값을 확인해 `true`면 Writer 인스턴스, `false` 또는 `undefined`면 Reader 인스턴스로 쿼리를 전달함

<br/>

(나머지 설명은 코멘트로 남겨두겠습니다)